### PR TITLE
Fix skipStories configuration key format

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ Example `package.json`:
         "height": 768
       },
       "chrome.iphone7": {
-        "skip-stories": "loading|MyFailingComponent",
+        "skipStories": "loading|MyFailingComponent",
         "target": "chrome.app",
         "preset": "iPhone 7"
       },


### PR DESCRIPTION
In the documentation example it's spelled as `skip-stories` but the actual property is `skipStories`.